### PR TITLE
Make using a particular source as a listener source configurable

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,8 +8,9 @@ import (
 )
 
 type K8sSource struct {
-	Name       string `json:"name"`
-	KubeConfig string `json:"kubeconfig"`
+	Name           string `json:"name"`
+	KubeConfig     string `json:"kubeconfig"`
+	ListenerSource bool   `json:"listenersource"`
 }
 
 func LoadSourcesConfig(path string) ([]K8sSource, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,12 +69,13 @@ func main() {
 
 		clusterSources = append(clusterSources, client)
 
-		lClient, err := listener.GetClient(s.KubeConfig)
-		if err != nil {
-			log.Fatal(fmt.Sprintf("getting client for k8s cluster: %s failed", s.Name), err)
+		if s.ListenerSource {
+			lClient, err := listener.GetClient(s.KubeConfig)
+			if err != nil {
+				log.Fatal(fmt.Sprintf("getting client for k8s cluster: %s failed", s.Name), err)
+			}
+			listenerSources = append(listenerSources, lClient)
 		}
-
-		listenerSources = append(listenerSources, lClient)
 	}
 
 	ca := cluster.NewClusterAggregator(clusterSources, *flagClusterNameAnno)

--- a/config.example.json
+++ b/config.example.json
@@ -2,11 +2,11 @@
   {
     "name": "aws",
     "kubeconfig": "/home/foivos/tempconfig/aws-kubeconf",
-    "role": "primary"
+    "listenersource": true
   },
   {
     "name": "gcp",
     "kubeconfig": "/home/foivos/tempconfig/gcp-kubeconf",
-    "role": "secondary"
+    "listenersource": false
   }
 ]


### PR DESCRIPTION
I think `listenersource` makes the purpose of the option clearer than `role`. Might have to revisit that naming if we add more CRDs in future.